### PR TITLE
Explicitly Increase Guava Dependency Version and Adopt Stopwatch Usage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ libraryDependencies ++= Seq(
     "com.google.http-client"	%   "google-http-client-jackson"    % "1.19.0",
     "ch.qos.logback"        	%   "logback-classic"         			% "1.1.3",
     "org.mockito"           	%   "mockito-all"             			% "1.10.19",
-    "org.specs2"            	%%  "specs2"                  			% "2.3.13"  	% "test"
+    "org.specs2"            	%%  "specs2"                  			% "2.3.13"  	% "test",
+    "com.google.guava"        % "guava"                           % "19.0"
 )
 
 resolvers ++= Seq(  "oss-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",

--- a/src/main/scala/com/themillhousegroup/gasket/traits/Timing.scala
+++ b/src/main/scala/com/themillhousegroup/gasket/traits/Timing.scala
@@ -1,5 +1,7 @@
 package com.themillhousegroup.gasket.traits
 
+import java.util.concurrent.TimeUnit
+
 import com.google.common.base.Stopwatch
 import org.slf4j.LoggerFactory
 
@@ -9,12 +11,12 @@ trait Timing {
 
   protected def time[T](opName: String, op: => T): T = {
     if (log.isDebugEnabled) {
-			val s = new Stopwatch()
+      val s = Stopwatch.createUnstarted()
       s.reset
       s.start
       val result: T = op
       s.stop
-      log.debug(s"$opName took ${s.elapsedMillis}ms")
+      log.debug(s"$opName took ${s.elapsed(TimeUnit.MILLISECONDS)}ms")
       result
     } else op
   }

--- a/src/test/scala/com/themillhousegroup/gasket/test/ExampleSpreadsheetFetcher.scala
+++ b/src/test/scala/com/themillhousegroup/gasket/test/ExampleSpreadsheetFetcher.scala
@@ -10,14 +10,14 @@ import scala.collection.mutable.Map
 object ExampleSpreadsheetFetcher extends TestHelpers {
   import scala.concurrent.ExecutionContext.Implicits.global
 
-	private val credentialAccountMap:scala.collection.mutable.Map[String, Future[Account]] = scala.collection.mutable.Map() 
+  private val credentialAccountMap: scala.collection.mutable.Map[String, Future[Account]] = scala.collection.mutable.Map()
 
-	private def lazyFetchAccount(clientId:String, p12File: File): Future[Account] = {
- 		if (!credentialAccountMap.contains(clientId)) {
-			credentialAccountMap.put(clientId, Account(clientId, p12File))
-		}	
-		credentialAccountMap(clientId)
-	}
+  private def lazyFetchAccount(clientId: String, p12File: File): Future[Account] = {
+    if (!credentialAccountMap.contains(clientId)) {
+      credentialAccountMap.put(clientId, Account(clientId, p12File))
+    }
+    credentialAccountMap(clientId)
+  }
 
   def fetchSheet(clientId: String, p12File: File, sheetName: String): Future[Worksheet] = {
     for {


### PR DESCRIPTION
The Timing trait made use of deprecated `Stopwatch` calls based on the old Guava version being transitively loaded with the `gdata` library.
Relying on these deprecated methods makes it impossible to use the library in more recent project, if these include libraries that rely on a Guava version where the deprecated methods are already removed. This results in a `java.lang.IllegalAccessError` at runtime because the old Guava library the `Timing` trait relies on might be evicted by a potential more recent version.
This commit explicitly includes the latest Guava version and adopts the usage of the `Stopwatch` class in the `Timing` trait accordingly.
